### PR TITLE
fix: who we are wording and centered sections layout

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import WaitingListForm from "./WaitingListForm";
-import "./index.css"; // must stay
+import "./index.css";
 
 // LinkedIn Icon SVG component
 const LinkedInIcon = () => (
@@ -62,7 +62,7 @@ export default function App() {
       <section className="brand-story">
         <h2>Who We Are</h2>
         <p className="mission">
-          We're students and crypto builders lowering the barrier to digital wealth. 
+          We're crypto builders and enthusiasts lowering the barrier to digital wealth. 
           Investing should be simple, stress-free, and built for this generation.
         </p>
         <div className="values-grid">

--- a/src/index.css
+++ b/src/index.css
@@ -604,6 +604,15 @@ p {
   .values-grid,
   .team-grid {
     grid-template-columns: repeat(2, 1fr);
+    justify-items: center;
+  }
+  @media (min-width: 769px) {
+    .steps-grid > :nth-last-child(1):nth-child(odd),
+    .values-grid > :nth-last-child(1):nth-child(odd),
+    .team-grid > :nth-last-child(1):nth-child(odd) {
+      grid-column: 1 / span 2;
+      justify-self: center;
+    }
   }
 
 }


### PR DESCRIPTION
Changed the wording to say that we are "crypto builders and enthusiasts" and centered the items for three of the sections in different view dimensions